### PR TITLE
Fix/update links

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,16 +22,16 @@
       <div class="container top-bar-left">
         <ul class="list-container menu dropdown">
           <li class="list-item-container menuitem">
-            <a class="link-text menu-link" href="index.html">Home</a>
+            <a class="link-text menu-link" href="/">Home</a>
           </li>
           <li class="list-item-container menuitem">
-            <a class="link-text menu-link smooth-scroll" href="https://rpaladin.github.io/features">Features</a>
+            <a class="link-text menu-link smooth-scroll" href="https://armory3d.org/features">Features</a>
           </li>
           <li class="list-item-container menuitem">
-            <a class="link-text menu-link" href="https://rpaladin.github.io/faq">FAQ</a>
+            <a class="link-text menu-link" href="https://armory3d.org/faq">FAQ</a>
           </li>
           <li class="list-item-container menuitem">
-            <a class="link-text menu-link smooth-scroll" href="https://rpaladin.github.io/community" title="">Community</a>
+            <a class="link-text menu-link smooth-scroll" href="https://armory3d.org/community" title="">Community</a>
           </li>
           <li class="list-item-container menuitem">
             <a class="link-text menu-link smooth-scroll" href="services.html">Learn</a>

--- a/services.html
+++ b/services.html
@@ -22,16 +22,16 @@
       <div class="container top-bar-left">
         <ul class="list-container menu dropdown">
           <li class="list-item-container menuitem">
-            <a class="link-text menu-link" href="index.html">Home</a>
+            <a class="link-text menu-link" href="/">Home</a>
           </li>
           <li class="list-item-container menuitem">
-            <a class="link-text menu-link smooth-scroll" href="https://rpaladin.github.io/features">Features</a>
+            <a class="link-text menu-link smooth-scroll" href="https://armory3d.org/features">Features</a>
           </li>
           <li class="list-item-container menuitem">
-            <a class="link-text menu-link" href="https://rpaladin.github.io/faq">FAQ</a>
+            <a class="link-text menu-link" href="https://armory3d.org/faq">FAQ</a>
           </li>
           <li class="list-item-container menuitem">
-            <a class="link-text menu-link smooth-scroll" href="https://rpaladin.github.io/community" title="">Community</a>
+            <a class="link-text menu-link smooth-scroll" href="https://armory3d.org/community" title="">Community</a>
           </li>
           <li class="list-item-container menuitem">
             <a class="link-text menu-link smooth-scroll" href="services.html">Learn</a>


### PR DESCRIPTION
* Point `rpaladin.github.io` links to `armory3d.org` now that the migration is over.
* Point `index.html` links to `/` to prevent unprofessional exposure of the index URL.